### PR TITLE
fix ATS handling for 14443a-4 cards

### DIFF
--- a/sam_api.c
+++ b/sam_api.c
@@ -21,6 +21,10 @@ char asn1_log[SEADER_UART_RX_BUF_SIZE] = {0};
 
 uint8_t updateBlock2[] = {RFAL_PICOPASS_CMD_UPDATE, 0x02};
 
+uint8_t select_seos_app[] =
+    {0x00, 0xa4, 0x04, 0x00, 0x0a, 0xa0, 0x00, 0x00, 0x04, 0x40, 0x00, 0x01, 0x01, 0x00, 0x01, 0x00};
+uint8_t FILE_NOT_FOUND[] = {0x6a, 0x82};
+
 void* calloc(size_t count, size_t size) {
     return malloc(count * size);
 }
@@ -744,14 +748,20 @@ void seader_iso14443a_transmit(
     BitBuffer* rx_buffer = bit_buffer_alloc(SEADER_POLLER_MAX_BUFFER_SIZE);
 
     do {
-        bit_buffer_append_bytes(tx_buffer, buffer, len);
+        if(credential->isDesfire && sizeof(select_seos_app) == len &&
+           memcmp(buffer, select_seos_app, len) == 0) {
+            FURI_LOG_I(TAG, "Intercept SELECT SeosApp to DESFire card and return File Not Found");
+            bit_buffer_append_bytes(rx_buffer, FILE_NOT_FOUND, sizeof(FILE_NOT_FOUND));
+        } else {
+            bit_buffer_append_bytes(tx_buffer, buffer, len);
 
-        Iso14443_4aError error =
-            iso14443_4a_poller_send_block(iso14443_4a_poller, tx_buffer, rx_buffer);
-        if(error != Iso14443_4aErrorNone) {
-            FURI_LOG_W(TAG, "iso14443_4a_poller_send_block error %d", error);
-            seader_worker->stage = SeaderPollerEventTypeFail;
-            break;
+            Iso14443_4aError error =
+                iso14443_4a_poller_send_block(iso14443_4a_poller, tx_buffer, rx_buffer);
+            if(error != Iso14443_4aErrorNone) {
+                FURI_LOG_W(TAG, "iso14443_4a_poller_send_block error %d", error);
+                seader_worker->stage = SeaderPollerEventTypeFail;
+                break;
+            }
         }
 
         seader_capture_sio(tx_buffer, rx_buffer, credential);

--- a/seader_credential.h
+++ b/seader_credential.h
@@ -42,7 +42,7 @@ typedef struct {
     uint8_t diversifier[8];
     uint8_t diversifier_len;
     uint8_t sio_start_block; // for iClass SE vs iClass SR
-    bool isDesfire;
+    bool isDesfireEV2;
     SeaderCredentialType type;
     SeaderCredentialSaveFormat save_format;
     char name[SEADER_CRED_NAME_MAX_LEN + 1];

--- a/seader_worker.c
+++ b/seader_worker.c
@@ -281,12 +281,26 @@ NfcCommand seader_worker_poller_callback_iso14443_4a(NfcGenericEvent event, void
             size_t uid_len;
             const uint8_t* uid = nfc_device_get_uid(seader->nfc_device, &uid_len);
 
-            const Iso14443_3aData* iso14443_3a_data =
-                nfc_device_get_data(seader->nfc_device, NfcProtocolIso14443_3a);
+            const Iso14443_4aData* iso14443_4a_data =
+                nfc_device_get_data(seader->nfc_device, NfcProtocolIso14443_4a);
+            const Iso14443_3aData* iso14443_3a_data = iso14443_4a_get_base_data(iso14443_4a_data);
+            uint32_t ats_len = 0;
+            uint8_t* ats = NULL;
+            if(iso14443_4a_data->ats_data.t1_tk != NULL) {
+                // for some reason Seos cards fail to read the ATS
+                SimpleArray* ats_array = iso14443_4a_data->ats_data.t1_tk;
+                ats_len = simple_array_get_count(ats_array);
+                if(ats_len > 0xFF) {
+                    ats_len = 0;
+                }
+                if(ats_len > 0) {
+                    ats = simple_array_get_data(ats_array);
+                }
+            }
             uint8_t sak = iso14443_3a_get_sak(iso14443_3a_data);
 
             seader_worker_card_detect(
-                seader, sak, (uint8_t*)iso14443_3a_data->atqa, uid, uid_len, NULL, 0);
+                seader, sak, (uint8_t*)iso14443_3a_data->atqa, uid, uid_len, ats, ats_len);
 
             // nfc_set_fdt_poll_fc(event.instance, SEADER_POLLER_MAX_FWT);
             furi_thread_set_current_priority(FuriThreadPriorityLowest);

--- a/seader_worker_i.h
+++ b/seader_worker_i.h
@@ -15,7 +15,8 @@
 #include <SamVersion.h>
 
 #define SEADER_POLLER_MAX_FWT         (200000U)
-#define SEADER_POLLER_MAX_BUFFER_SIZE (255U)
+// Maximum basic rAPDU size is 256 bytes of data + 2 byte SW
+#define SEADER_POLLER_MAX_BUFFER_SIZE (258U)
 
 // ATS bit definitions
 #define ISO14443_4A_ATS_T0_TA1 (1U << 4)

--- a/seader_worker_i.h
+++ b/seader_worker_i.h
@@ -17,6 +17,11 @@
 #define SEADER_POLLER_MAX_FWT         (200000U)
 #define SEADER_POLLER_MAX_BUFFER_SIZE (255U)
 
+// ATS bit definitions
+#define ISO14443_4A_ATS_T0_TA1 (1U << 4)
+#define ISO14443_4A_ATS_T0_TB1 (1U << 5)
+#define ISO14443_4A_ATS_T0_TC1 (1U << 6)
+
 struct SeaderWorker {
     FuriThread* thread;
     Storage* storage;


### PR DESCRIPTION
preivously the ATS was always filled with the ATQA which caused some oddities with DESFire EV2 and newer cards

this change populates the ATS which removes the need for the EV2 workaround

for Seos cards however the ATS does not appear to be being returned by the flipper firmware (perhaps an upstream bug?) but for Seos the ATS doesn't matter as long as "something" is present, so we retain the previous behaviour of filling in the ATQA for part4 cards

tested with defire ev3, ev1, and seos cards and all read fine now